### PR TITLE
homework_26

### DIFF
--- a/api_tests_bstepchenko/conftest.py
+++ b/api_tests_bstepchenko/conftest.py
@@ -1,6 +1,13 @@
 import pytest
 import requests
+
 from api_tests_bstepchenko.data import constants
+from api_tests_bstepchenko.endpoints.get_object import GetObject
+from api_tests_bstepchenko.endpoints.post_object import PostObject
+from api_tests_bstepchenko.endpoints.put_object import PutObject
+from api_tests_bstepchenko.endpoints.patch_object import PatchObject
+from api_tests_bstepchenko.endpoints.del_object import DeleteObject
+from api_tests_bstepchenko.data.randomizer import get_random_int, get_random_str
 
 
 @pytest.fixture(scope='class')
@@ -12,10 +19,42 @@ def start_end():
 
 @pytest.fixture(scope='function')
 def create_and_delete_object():
-    payload = constants.PAYLOAD_FOR_OBJECT
+    payload = {
+        "name": get_random_str(),
+        "data": {
+            "year": get_random_int(),
+            "price": get_random_int(),
+            "CPU model": get_random_str(),
+        },
+    }
     creation_response = requests.post(f'{constants.BASE_URL}',
                                       json=payload, headers=constants.HEADERS)
     created_object = creation_response.json()
     assert created_object is not None, "Failed to create the object"
-    yield created_object['id']
+    yield created_object['id'], payload
     requests.delete(f'{constants.BASE_URL}/{created_object["id"]}')
+
+
+@pytest.fixture(scope='function')
+def get_object_endpoint():
+    return GetObject()
+
+
+@pytest.fixture(scope='function')
+def post_object_endpoint():
+    return PostObject()
+
+
+@pytest.fixture(scope='function')
+def put_object_endpoint():
+    return PutObject()
+
+
+@pytest.fixture(scope='function')
+def patch_object_endpoint():
+    return PatchObject()
+
+
+@pytest.fixture(scope='function')
+def delete_object_endpoint():
+    return DeleteObject()

--- a/api_tests_bstepchenko/endpoints/base_api.py
+++ b/api_tests_bstepchenko/endpoints/base_api.py
@@ -1,3 +1,6 @@
+from abc import abstractmethod
+
+
 class BaseApi:
     def __init__(self):
         self.payload = None
@@ -7,14 +10,9 @@ class BaseApi:
     def check_response_code_is_(self, code):
         assert self.response.status_code == code
 
-    def check_updated_name(self):
-        assert self.response_json['name'] == self.payload['name']
+    @abstractmethod
+    def data(self):
+        pass
 
-    def check_updated_year(self):
-        assert self.response_json['data']['year'] == self.payload['data']['year']
-
-    def check_updated_price(self):
-        assert self.response_json['data']['price'] == self.payload['data']['price']
-
-    def check_updated_cpu_model(self):
-        assert self.response_json['data']['CPU model'] == self.payload['data']['CPU model']
+    def response_json(self):
+        return self.response.json()

--- a/api_tests_bstepchenko/endpoints/get_object.py
+++ b/api_tests_bstepchenko/endpoints/get_object.py
@@ -1,7 +1,9 @@
+from json import JSONDecodeError
+
 import requests
-from requests.exceptions import JSONDecodeError
 from api_tests_bstepchenko.data import constants
 from api_tests_bstepchenko.endpoints.base_api import BaseApi
+from api_tests_bstepchenko.models.object_data import ObjectJson
 
 
 class GetObject(BaseApi):
@@ -11,4 +13,21 @@ class GetObject(BaseApi):
         try:
             self.response_json = self.response.json()
         except JSONDecodeError:
-            pass
+            assert False, "Failed to decode JSON response"
+
+    @property
+    def data(self):
+        return ObjectJson(**self.response_json)
+
+    def check_name(self, payload):
+        assert self.data.name == payload['name']
+
+    def check_year(self, payload):
+        assert self.data.data.year == payload['data']['year']
+
+    def check_price(self, payload):
+        assert self.data.data.price == payload['data']['price']
+
+    def check_cpu_model(self, payload):
+        assert self.data.data.CPU_model == payload['data']['CPU model']
+

--- a/api_tests_bstepchenko/endpoints/get_object.py
+++ b/api_tests_bstepchenko/endpoints/get_object.py
@@ -30,4 +30,3 @@ class GetObject(BaseApi):
 
     def check_cpu_model(self, payload):
         assert self.data.data.CPU_model == payload['data']['CPU model']
-

--- a/api_tests_bstepchenko/endpoints/patch_object.py
+++ b/api_tests_bstepchenko/endpoints/patch_object.py
@@ -2,6 +2,7 @@ import requests
 from api_tests_bstepchenko.data import constants
 from requests.exceptions import JSONDecodeError
 from api_tests_bstepchenko.endpoints.base_api import BaseApi
+from api_tests_bstepchenko.models.object_data import ObjectJson
 
 
 class PatchObject(BaseApi):
@@ -14,3 +15,19 @@ class PatchObject(BaseApi):
             self.response_json = self.response.json()
         except JSONDecodeError:
             pass
+
+    @property
+    def data(self):
+        return ObjectJson(**self.response_json)
+
+    def check_updated_name(self, payload):
+        assert self.data.name == payload['name']
+
+    def check_updated_year(self, payload):
+        assert self.data.data.year == payload['data']['year']
+
+    def check_updated_price(self, payload):
+        assert self.data.data.price == payload['data']['price']
+
+    def check_updated_cpu_model(self, payload):
+        assert self.data.data.CPU_model == payload['data']['CPU model']

--- a/api_tests_bstepchenko/endpoints/post_object.py
+++ b/api_tests_bstepchenko/endpoints/post_object.py
@@ -2,14 +2,30 @@ import requests
 from api_tests_bstepchenko.data import constants
 from requests.exceptions import JSONDecodeError
 from api_tests_bstepchenko.endpoints.base_api import BaseApi
+from api_tests_bstepchenko.models.object_data import ObjectJson
 
 
 class PostObject(BaseApi):
 
-    def post_new_object(self):
-        self.payload = constants.PAYLOAD_FOR_OBJECT
-        self.response = requests.post(f'{constants.BASE_URL}', json=self.payload, headers=constants.HEADERS)
+    def post_new_object(self, payload):
+        self.response = requests.post(f'{constants.BASE_URL}', json=payload, headers=constants.HEADERS)
         try:
             self.response_json = self.response.json()
         except JSONDecodeError:
             pass
+
+    @property
+    def data(self):
+        return ObjectJson(**self.response_json)
+
+    def check_updated_name(self, payload):
+        assert self.data.name == payload['name']
+
+    def check_updated_year(self, payload):
+        assert self.data.data.year == payload['data']['year']
+
+    def check_updated_price(self, payload):
+        assert self.data.data.price == payload['data']['price']
+
+    def check_updated_cpu_model(self, payload):
+        assert self.data.data.CPU_model == payload['data']['CPU model']

--- a/api_tests_bstepchenko/endpoints/put_object.py
+++ b/api_tests_bstepchenko/endpoints/put_object.py
@@ -2,6 +2,7 @@ import requests
 from api_tests_bstepchenko.data import constants
 from requests.exceptions import JSONDecodeError
 from api_tests_bstepchenko.endpoints.base_api import BaseApi
+from api_tests_bstepchenko.models.object_data import ObjectJson
 
 
 class PutObject(BaseApi):
@@ -12,5 +13,22 @@ class PutObject(BaseApi):
                                      json=self.payload, headers=constants.HEADERS)
         try:
             self.response_json = self.response.json()
+            print(self.response_json)
         except JSONDecodeError:
             pass
+
+    @property
+    def data(self):
+        return ObjectJson(**self.response_json)
+
+    def check_updated_name(self, payload):
+        assert self.data.name == payload['name']
+
+    def check_updated_year(self, payload):
+        assert self.data.data.year == payload['data']['year']
+
+    def check_updated_price(self, payload):
+        assert self.data.data.price == payload['data']['price']
+
+    def check_updated_cpu_model(self, payload):
+        assert self.data.data.CPU_model == payload['data']['CPU model']

--- a/api_tests_bstepchenko/models/object_data.py
+++ b/api_tests_bstepchenko/models/object_data.py
@@ -1,0 +1,12 @@
+from pydantic import Field, BaseModel
+
+
+class ObjectDataJson(BaseModel):
+    year: int or list[int]
+    price: float
+    CPU_model: str = Field(alias='CPU model')
+
+
+class ObjectJson(BaseModel):
+    name: str
+    data: ObjectDataJson

--- a/api_tests_bstepchenko/tests/test_objects.py
+++ b/api_tests_bstepchenko/tests/test_objects.py
@@ -1,11 +1,6 @@
 import pytest
 import allure
 from api_tests_bstepchenko.data import constants
-from api_tests_bstepchenko.endpoints.get_object import GetObject
-from api_tests_bstepchenko.endpoints.post_object import PostObject
-from api_tests_bstepchenko.endpoints.put_object import PutObject
-from api_tests_bstepchenko.endpoints.patch_object import PatchObject
-from api_tests_bstepchenko.endpoints.del_object import DeleteObject
 
 
 @allure.feature('Homework #23 tests')
@@ -15,57 +10,57 @@ class TestAPIClient:
     @allure.title('Creation object test')
     @allure.description('That test is about creation object for following tests')
     @allure.severity('Critical')
-    def test_creation_object(self):
-        post_obj_endpoint = PostObject()
-        post_obj_endpoint.post_new_object()
-        post_obj_endpoint.check_response_code_is_(200)
-        post_obj_endpoint.check_updated_name()
-        post_obj_endpoint.check_updated_year()
-        post_obj_endpoint.check_updated_price()
-        post_obj_endpoint.check_updated_cpu_model()
+    def test_creation_object(self, post_object_endpoint):
+        payload = constants.PAYLOAD_FOR_OBJECT
+        post_object_endpoint.post_new_object(payload)
+        post_object_endpoint.check_response_code_is_(200)
+        post_object_endpoint.check_updated_name(payload)
+        post_object_endpoint.check_updated_year(payload)
+        post_object_endpoint.check_updated_price(payload)
+        post_object_endpoint.check_updated_cpu_model(payload)
 
     @allure.title('Getting exact object test')
     @allure.severity('Minor')
-    def test_get_exact_object(self, create_and_delete_object):
-        get_obj_endpoint = GetObject()
-        get_obj_endpoint.get_object_by_id(create_and_delete_object)
-        get_obj_endpoint.check_response_code_is_(200)
+    def test_get_exact_object(self, create_and_delete_object, get_object_endpoint):
+        object_id, payload = create_and_delete_object
+        get_object_endpoint.get_object_by_id(object_id)
+        get_object_endpoint.check_response_code_is_(200)
+        get_object_endpoint.check_name(payload)
+        get_object_endpoint.check_year(payload)
+        get_object_endpoint.check_price(payload)
+        get_object_endpoint.check_cpu_model(payload)
 
     @allure.title('Updating object with PUT test')
     @pytest.mark.parametrize('name', ['ABCdef', '   ', '!@#$%'],
                              ids=['letters', 'spaces', 'symbols']
                              )
-    @pytest.mark.parametrize('year', [1993, [2024]], ids=['old', 'new'])
+    @pytest.mark.parametrize('year', [1993, 2024], ids=['old', 'new'])
     @pytest.mark.parametrize('price', [1, 100000], ids=['small', 'huge'])
-    def test_update_object_with_put(self, create_and_delete_object, name, price, year):
-        put_obj_endpoint = PutObject()
-        payload = constants.PAYLOAD_FOR_OBJECT
-        payload['name'] = name
-        payload['data']['price'] = price
-        payload['data']['year'] = year
-        put_obj_endpoint.update_obj_with_put(create_and_delete_object, payload)
-        put_obj_endpoint.check_response_code_is_(200)
-        put_obj_endpoint.check_updated_name()
-        put_obj_endpoint.check_updated_year()
-        put_obj_endpoint.check_updated_price()
-        put_obj_endpoint.check_updated_cpu_model()
+    def test_update_object_with_put(self, create_and_delete_object, put_object_endpoint, name, price, year):
+        object_id, payload = create_and_delete_object
+        put_object_endpoint.update_obj_with_put(object_id, payload)
+        put_object_endpoint.check_response_code_is_(200)
+        put_object_endpoint.check_updated_name(payload)
+        put_object_endpoint.check_updated_year(payload)
+        put_object_endpoint.check_updated_price(payload)
+        put_object_endpoint.check_updated_cpu_model(payload)
 
     @allure.title('Updating object with PATCH test')
-    def test_update_object_with_patch(self, create_and_delete_object):
-        patch_obj_endpoint = PatchObject()
-        patch_obj_endpoint.update_obj_with_patch(create_and_delete_object)
-        patch_obj_endpoint.check_response_code_is_(200)
-        patch_obj_endpoint.check_updated_name()
-        patch_obj_endpoint.check_updated_price()
-        patch_obj_endpoint.check_updated_year()
-        patch_obj_endpoint.check_updated_cpu_model()
+    def test_update_object_with_patch(self, create_and_delete_object, patch_object_endpoint):
+        object_id, payload = create_and_delete_object
+        patch_object_endpoint.update_obj_with_patch(object_id)
+        patch_object_endpoint.check_response_code_is_(200)
+        payload = constants.PAYLOAD_FOR_OBJECT
+        patch_object_endpoint.check_updated_name(payload)
+        patch_object_endpoint.check_updated_price(payload)
+        patch_object_endpoint.check_updated_year(payload)
+        patch_object_endpoint.check_updated_cpu_model(payload)
 
     @allure.title('Deletion object test')
     @allure.severity('Critical')
-    def test_deletion_object(self):
-        del_obj_endpoint = DeleteObject()
-        new_object = del_obj_endpoint.create_new_object()
-        del_obj_endpoint.check_response_code_is_(200)
-        del_obj_endpoint.delete_created_object(new_object)
-        del_obj_endpoint.check_response_code_is_(200)
-        del_obj_endpoint.check_obj_absense(new_object)
+    def test_deletion_object(self, delete_object_endpoint):
+        new_object = delete_object_endpoint.create_new_object()
+        delete_object_endpoint.check_response_code_is_(200)
+        delete_object_endpoint.delete_created_object(new_object)
+        delete_object_endpoint.check_response_code_is_(200)
+        delete_object_endpoint.check_obj_absense(new_object)


### PR DESCRIPTION
- добавил в models.py схемы для pydantic
- добавил фикстуры инициализации классов (чтобы убрать это из самих тестов)
- немного подполишил сами эндпойнты (методы на проверку полей вынес из базового эндпойнта в конкретные)

Вопрос:
У меня инициализация payload происходит в фикстуре create_and_delete_object.
И я заметил, что у меня во всех тестах идентичный пэйлод - я так понял из-за того, что эта фикстура генерит payload только 1 раз за все время тестов.
Поэтому я в ней добавил в yield не только получение id но и получения payload.
Сообственно из-за этого у меня почти все тесткейсы теперь имеют строчку:
object_id, payload = create_and_delete_object
Чтобы использовать payload из созданного обьекта в дальнейших проверках. Например: 
    def check_updated_year(self, payload):
        assert self.data.data.year == payload['data']['year']
        
Насколько это нормальное решение впринципе?
Я о добавлении строки: object_id, payload = create_and_delete_object в тесткейсах